### PR TITLE
Fully remove version checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,4 +229,4 @@ module.exports = fastifyPlugin((instance, opts, next) => {
     });
 
   next();
-}, ">=0.x");
+});


### PR DESCRIPTION
I've tested this module is compatible with upcoming `fastify` 2.0.0, currently in release candidate, but the version checking makes it incompatible, and changing it to be compatible with 2.x would remove backwards compatibility for nothing. By removing the version checking, it works for any current or future versions without changes.